### PR TITLE
Make rpm_gpgkey able to handle remote paths

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,25 +20,24 @@
 #   Key ID as string.
 #
 define rpm_gpgkey($path, $keyid) {
-
-  if $path !~ /^\// {
-    $realpath = "/etc/pki/rpm-gpg/${path}"
-  }
-  else {
-    $realpath = $path
-  }
-
   # quote keyid to explicitly stringify it, as hiera will return an
   # integer if the hexadecimal number includes only digits 0-9. downcase()
   # doesn't know what to do with an integer.
   $realkeyid = downcase("${keyid}")
 
   if $path =~ /^(f|ht)tps?:/ {
+    # If remote URL for key, just try to do it
     exec { "rpm-gpg-import-${name}":
       command => "/bin/rpm --import ${realpath}",
       unless  => "/bin/rpm --quiet -q gpg-pubkey-${realkeyid}",
     }
   } else {
+    if $path !~ /^\// {
+      $realpath = "/etc/pki/rpm-gpg/${path}"
+    }
+    else {
+      $realpath = $path
+    }
     exec { "rpm-gpg-import-${name}":
       command => "/bin/rpm --import ${realpath}",
       unless  => "/bin/rpm --quiet -q gpg-pubkey-${realkeyid}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ define rpm_gpgkey($path, $keyid) {
   if $path =~ /^(f|ht)tps?:/ {
     # If remote URL for key, just try to do it
     exec { "rpm-gpg-import-${name}":
-      command => "/bin/rpm --import ${realpath}",
+      command => "/bin/rpm --import ${path}",
       unless  => "/bin/rpm --quiet -q gpg-pubkey-${realkeyid}",
     }
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,9 +20,6 @@
 #   Key ID as string.
 #
 define rpm_gpgkey($path, $keyid) {
-  if $path =~ /^(f|ht)tps?:/ {
-    fail('rpm_gpgkey does not work with remote paths!')
-  }
 
   if $path !~ /^\// {
     $realpath = "/etc/pki/rpm-gpg/${path}"
@@ -36,10 +33,17 @@ define rpm_gpgkey($path, $keyid) {
   # doesn't know what to do with an integer.
   $realkeyid = downcase("${keyid}")
 
-  exec { "rpm-gpg-import-${name}":
-    command => "/bin/rpm --import ${realpath}",
-    unless  => "/bin/rpm --quiet -q gpg-pubkey-${realkeyid}",
-    onlyif  => "/usr/bin/test -f ${realpath}",
+  if $path =~ /^(f|ht)tps?:/ {
+    exec { "rpm-gpg-import-${name}":
+      command => "/bin/rpm --import ${realpath}",
+      unless  => "/bin/rpm --quiet -q gpg-pubkey-${realkeyid}",
+    }
+  } else {
+    exec { "rpm-gpg-import-${name}":
+      command => "/bin/rpm --import ${realpath}",
+      unless  => "/bin/rpm --quiet -q gpg-pubkey-${realkeyid}",
+      onlyif  => "/usr/bin/test -f ${realpath}",
+    }
   }
 }
 #


### PR DESCRIPTION
Since the `rpm --import` command is able to handle remote http sources, it's reasonably easy to change this module to be able to work with local or remote paths.